### PR TITLE
Feature/autowire includes

### DIFF
--- a/src/Exception/IncludeException.php
+++ b/src/Exception/IncludeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Exception;
+
+class IncludeException extends \Exception
+{
+
+}

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -2,6 +2,7 @@
 
 namespace Rexlabs\Smokescreen;
 
+use Rexlabs\Smokescreen\Exception\IncludeException;
 use Rexlabs\Smokescreen\Exception\InvalidTransformerException;
 use Rexlabs\Smokescreen\Exception\MissingResourceException;
 use Rexlabs\Smokescreen\Exception\UnhandledResourceType;
@@ -64,11 +65,12 @@ class Smokescreen implements \JsonSerializable
     /**
      * Set the resource item to be transformed.
      *
-     * @param mixed                              $data
+     * @param mixed                           $data
      * @param TransformerInterface|mixed|null $transformer
-     * @param string|null                        $key
+     * @param string|null                     $key
      *
      * @return $this
+     * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      */
     public function item($data, $transformer = null, $key = null)
     {
@@ -80,12 +82,13 @@ class Smokescreen implements \JsonSerializable
     /**
      * Set the resource collection to be transformed.
      *
-     * @param mixed                              $data
+     * @param mixed                           $data
      * @param TransformerInterface|mixed|null $transformer
-     * @param string|null                        $key
-     * @param callable|null                      $callback
+     * @param string|null                     $key
+     * @param callable|null                   $callback
      *
      * @return $this
+     * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      */
     public function collection($data, TransformerInterface $transformer = null, $key = null, callable $callback = null)
     {
@@ -140,6 +143,7 @@ class Smokescreen implements \JsonSerializable
      * @throws \Rexlabs\Smokescreen\Exception\JsonEncodeException
      *
      * @return \stdClass
+     * @throws IncludeException
      */
     public function toObject(): \stdClass
     {
@@ -157,6 +161,7 @@ class Smokescreen implements \JsonSerializable
      * @throws \Rexlabs\Smokescreen\Exception\JsonEncodeException
      *
      * @return string
+     * @throws IncludeException
      */
     public function toJson($options = 0): string
     {
@@ -174,6 +179,7 @@ class Smokescreen implements \JsonSerializable
      * @return array
      *
      * @see Smokescreen::toArray()
+     * @throws IncludeException
      */
     public function jsonSerialize(): array
     {
@@ -188,6 +194,7 @@ class Smokescreen implements \JsonSerializable
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
      *
      * @return array
+     * @throws IncludeException
      */
     public function toArray(): array
     {
@@ -329,6 +336,7 @@ class Smokescreen implements \JsonSerializable
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      *
      * @return array|mixed
+     * @throws IncludeException
      */
     protected function serializeResource($resource, Includes $includes): array
     {
@@ -375,6 +383,7 @@ class Smokescreen implements \JsonSerializable
      * @throws InvalidTransformerException
      *
      * @return array
+     * @throws IncludeException
      */
     protected function serializeCollection(Collection $collection, Includes $includes): array
     {
@@ -415,10 +424,12 @@ class Smokescreen implements \JsonSerializable
      * @param mixed|TransformerInterface|callable|null $transformer
      * @param Includes                                 $includes
      *
+     * @throws \Rexlabs\Smokescreen\Exception\InvalidSerializerException
      * @throws \Rexlabs\Smokescreen\Exception\UnhandledResourceType
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      *
      * @return array
+     * @throws IncludeException
      */
     protected function transformItem($item, $transformer, Includes $includes): array
     {
@@ -476,7 +487,7 @@ class Smokescreen implements \JsonSerializable
         // Add includes to the payload
         $includeMap = $transformer->getIncludeMap();
         foreach ($mappedIncludeKeys as $includeKey) {
-            $resource = $this->executeTransformerInclude($transformer, $includeMap[$includeKey], $item);
+            $resource = $this->executeTransformerInclude($transformer, $includeKey, $includeMap[$includeKey], $item);
 
             if ($resource instanceof ResourceInterface) {
                 // Resource object
@@ -494,15 +505,59 @@ class Smokescreen implements \JsonSerializable
     /**
      * Execute the transformer.
      *
-     * @param mixed $transformer
-     * @param array $include
-     * @param mixed $item
+     * @param mixed  $transformer
+     * @param string $includeKey
+     * @param array  $includeDefinition
+     * @param mixed  $item
      *
-     * @return mixed
+     * @return ResourceInterface
+     * @throws \Rexlabs\Smokescreen\Exception\UnhandledResourceType
+     * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
+     * @throws IncludeException
      */
-    protected function executeTransformerInclude($transformer, $include, $item)
+    protected function executeTransformerInclude($transformer, $includeKey, $includeDefinition, $item)
     {
-        return \call_user_func([$transformer, $include['method']], $item);
+        // Transformer explicitly provided an include method
+        $method = $includeDefinition['method'];
+        if (method_exists($transformer, $method)) {
+            return $transformer->$method($item);
+        }
+
+        // Otherwise try handle the include automatically
+        return $this->autoWireInclude($includeKey, $includeDefinition, $item);
+    }
+
+    /**
+     * @param string $includeKey
+     * @param array  $includeDefinition
+     * @param        $item
+     *
+     * @return Collection|Item
+     * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
+     * @throws IncludeException
+     */
+    protected function autoWireInclude($includeKey, $includeDefinition, $item)
+    {
+        // Get the included data
+        $data = null;
+        if (\is_array($item) || $item instanceof \ArrayAccess) {
+            $data = $item[$includeKey];
+        } elseif (\is_object($item) && property_exists($item, $includeKey)) {
+            $data = $item->$includeKey;
+        } else {
+            throw new IncludeException("Cannot auto-wire include for $includeKey: Cannot get include data");
+        }
+
+        // Wrap the included data in a resource
+        $resourceType = $includeDefinition['resource_type'] ?? 'item';
+        switch ($resourceType) {
+            case 'collection':
+                return new Collection($data);
+            case 'item':
+                return new Item($data);
+            default:
+                throw new IncludeException("Cannot auto-wire include for $includeKey: Invalid resource type $resourceType");
+        }
     }
 
     /**

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -344,7 +344,6 @@ class Smokescreen implements \JsonSerializable
      */
     protected function serializeResource($resource, Includes $includes): array
     {
-
         if ($resource instanceof ResourceInterface) {
             if (!$resource->hasTransformer()) {
                 // Try to resolve a transformer for a resource that does not have one assigned.
@@ -552,23 +551,19 @@ class Smokescreen implements \JsonSerializable
         // Get the included data
         $data = null;
         if (\is_array($item) || $item instanceof \ArrayAccess) {
-            $data = $item[$includeKey];
-        } elseif (\is_object($item) && property_exists($item, $includeKey)) {
-            $data = $item->$includeKey;
+            $data = $item[$includeKey] ?? null;
+        } elseif (\is_object($item)) {
+            $data = $item->$includeKey ?? null;
         } else {
             throw new IncludeException("Cannot auto-wire include for $includeKey: Cannot get include data");
         }
 
-        // Wrap the included data in a resource
-        $resourceType = $includeDefinition['resource_type'] ?? 'item';
-        switch ($resourceType) {
-            case 'collection':
-                return new Collection($data);
-            case 'item':
-                return new Item($data);
-            default:
-                throw new IncludeException("Cannot auto-wire include for $includeKey: Invalid resource type $resourceType");
+        if (!empty($includeDefinition['resource_type']) && $includeDefinition['resource_type'] === 'collection') {
+            return new Collection($data);
         }
+
+        // Assume unless declared, that the resource is an item.
+        return new Item($data);
     }
 
     /**

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -206,13 +206,6 @@ class Smokescreen implements \JsonSerializable
             throw new MissingResourceException('No resource has been defined to transform');
         }
 
-        // If there is no transformer assigned to the resource, we'll try find one.
-        if (!$this->resource->hasTransformer()) {
-            // Try to resolve one based on the underlying model (if any).
-            $transformer = $this->resolveTransformerForResource($this->resource);
-            $this->resource->setTransformer($transformer);
-        }
-
         // Kick of serialization of the resource
         return $this->serializeResource($this->resource, $this->getIncludes());
     }
@@ -351,8 +344,15 @@ class Smokescreen implements \JsonSerializable
      */
     protected function serializeResource($resource, Includes $includes): array
     {
-        // Load relations for any resource which implements the interface.
+
         if ($resource instanceof ResourceInterface) {
+            if (!$resource->hasTransformer()) {
+                // Try to resolve a transformer for a resource that does not have one assigned.
+                $transformer = $this->resolveTransformerForResource($resource);
+                $resource->setTransformer($transformer);
+            }
+
+            // Load relations for any resource which implements the interface.
             $this->loadRelations($resource);
         }
 
@@ -632,7 +632,7 @@ class Smokescreen implements \JsonSerializable
     /**
      * @return TransformerResolverInterface|null
      */
-    public function getTransformerResolver(): TransformerResolverInterface
+    public function getTransformerResolver()
     {
         return $this->transformerResolver;
     }

--- a/src/Transformer/AbstractTransformer.php
+++ b/src/Transformer/AbstractTransformer.php
@@ -91,6 +91,12 @@ class AbstractTransformer implements TransformerInterface
                                 $settings['method'] = $val;
                             }
                             break;
+                        case 'item':
+                            $settings['resource_type'] = 'item';
+                            break;
+                        case 'collection':
+                            $settings['resource_type'] = 'collection';
+                            break;
                         default:
                             throw new ParseDefinitionException("Invalid key '{$directive}' for {$includeKey}");
                     }
@@ -105,6 +111,9 @@ class AbstractTransformer implements TransformerInterface
             }
             if (!isset($settings['default'])) {
                 $settings['default'] = false;
+            }
+            if (!isset($settings['resource_type'])) {
+                $settings['resource_type'] = null;
             }
 
             $map[$includeKey] = $settings;

--- a/src/Transformer/TransformerResolverInterface.php
+++ b/src/Transformer/TransformerResolverInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Transformer;
+
+use Rexlabs\Smokescreen\Resource\ResourceInterface;
+
+interface TransformerResolverInterface
+{
+    /**
+     * Determines the Transformer object to be used for a particular resource.
+     *
+     * @param ResourceInterface $resource
+     * @return TransformerInterface|mixed|null
+     */
+    public function resolve(ResourceInterface $resource);
+}

--- a/tests/Unit/Transformer/AbstractTransformerTest.php
+++ b/tests/Unit/Transformer/AbstractTransformerTest.php
@@ -30,13 +30,15 @@ class AbstractTransformerTest extends TestCase
         $transformer = new class() extends AbstractTransformer {
             protected $includes = [
                 'user'    => 'method:includeUser',
-                'account' => 'method:includeAccount',
+                'account' => 'method:includeAccount|item',
+                'events' => 'collection'
             ];
         };
 
         $this->assertEquals([
             'user',
             'account',
+            'events',
         ], $transformer->getAvailableIncludes());
     }
 


### PR DESCRIPTION
# Feature: Auto-wire includes

The auto-wire includes feature, allows an include to be automatically resolved based on the `$includes` definition within a transformer.  This feature supplements the existing functionality where declared includes are mapped to an appropriate `include()` method on the transformer - instead the include can be declared with a resource type.

So now you can:

- Explicitly provide an `includeXXX()` method to handle custom logic.
- Or, simply add `collection` or `item` to your include definition  (`item` is assumed when omitted). This wraps your underlying data in either a `Collection` or `Item` resource so that the resolver has the necessary information.

## Transformer resolution

To provide auto-wired includes, it is necessary for smokescreen to be able to automatically resolve a transformer.

In order to accommodate this feature across the base package, we introduce `TransformerResolverInterface` which exposes a `resolve(ResourceInterface)` method.  This method is responsible for returning a transformer (instance of a class, callable etc.), based on the given resource. It may also return null if one cannot be resolved (Smokescreen can still handle resources that don't have transformers).

This allows framework packages (such as the [laravel](https://github.com/rexlabsio/smokescreen-laravel-php) one) to implement their own transformer mapping semantics.  

No implementation is provided in the base package.

## How it works

1. While serializing the top-level resource Smokescreen either has an explicit transformer, or will attempt to resolve one using the new `ResolverInterface` implementation (if one is defined).
2. If a `TransformerInterface` instance is explicitly provided or resolved, the include map can be fetched.
3. Smokescreen looks to see if there is a corresponding `includeX()` method for each declared include.  For example an include declaration of `author` will try to find a method called `includeAuthor()` on the transformer class.
4. If no method exists, the auto-wiring functionality will attempt to do what an include method normally does which is to return a new Collection or Item resource.  Include methods normally have an explicitly defined transformer instance, but in our case we don't have one, but we repeat this same process (steps 1-4) to handle the resource returned.

## Usage

Framework specific packages such as [laravel-smokescreen](https://github.com/rexlabsio/smokescreen-laravel-php) will implement their own concrete implementation TransformerResolverInterface and provide a way to map the underlying model/data to a transformer.

Example in the laravel package:

```php
<?php

namespace App\Transformers;

class ReceiverTransformer extends AbstractTransformer
{
    protected $includes = [
        'source' => 'relation',
        'application' => 'relation',
        'events' => 'relation|collection',
    ];

    protected $props = [
        'id',
        'application.id',
        'source.id',
        'created_at' => 'datetime',
        'updated_at' => 'datetime',
    ];
}
```

- In the above instance, `source`, `application` and `events` will be auto-wired because no specific include function is provided
- The default resource type assumed is `item`, so we declare that `events` is a `collection` resource
- Laravel package resolver see what type of model the underlying data is, fetch the transformer namespace prefix from config and return an instance of the transformer via laravels App container resolver

> Note: The above example also uses the declative props feature.

## When auto-wiring goes bad

There are certain cases where auto-wiring may not be ideal.

- If your transformer needs dependencies that need to be initialised (Eg. via constructor).  This would be true for stateful transformers that might take the current logged in user etc.  
- You might have some kind of conditional include/property within your include method.  This can't be handled automatically.

In both these cases you should provide an explicit include method on the transformer instead.

> Note: In the laravel package, the app container is used to instantiate the transformer so it may be able to wire those dependencies and/or you may be able to configure them in your service.

## Future

It might be a good idea to add a `map:name` directive to includes directive to tell auto-wiring what property it might be pulling off the model. Currently it uses the include key. 
