### PR TITLE
Document composition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "phpunit/phpunit": "^6.5.7",
     "codedungeon/phpunit-result-printer": "^0.5.4",
-    "squizlabs/php_codesniffer": "^3.4"
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,13 @@
       "email": "jodie.dunlop@rexsoftware.com.au"
     }
   ],
+  "require": {
+    "php": "^7.0"
+  },
   "require-dev": {
     "phpunit/phpunit": "^6.5.7",
-    "codedungeon/phpunit-result-printer": "^0.5.4"
+    "codedungeon/phpunit-result-printer": "^0.5.4",
+    "squizlabs/php_codesniffer": "^3.4"
   },
   "autoload": {
     "psr-4": {
@@ -34,7 +38,9 @@
   "scripts": {
     "test": "phpunit",
     "tests": "phpunit --colors=always",
-    "coverage": "phpunit --coverage-html ./tests/report"
+    "coverage": "phpunit --coverage-html ./tests/report",
+    "check-style": "phpcs -p -s --cache",
+    "fix-style": "phpcbf -p -s"
   },
   "license": "MIT"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abaf70a3772e4af8daa1dae79ec9a44a",
+    "content-hash": "0ea2a8b674c5c060651ed7a59c7dee84",
     "packages": [],
     "packages-dev": [
         {
@@ -19,7 +19,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/ce3b989eeb6d2b8cab367897275e120520bdca18",
                 "reference": "ce3b989eeb6d2b8cab367897275e120520bdca18",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "hassankhan/config": "^0.10.0",
@@ -123,7 +129,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/hassankhan/config/zipball/06ac500348af033f1a2e44dc357ca86282626d4a",
                 "reference": "06ac500348af033f1a2e44dc357ca86282626d4a",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": ">=5.3.0"
@@ -228,7 +240,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
                 "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "ext-dom": "*",
@@ -283,7 +301,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
                 "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^5.6 || ^7.0"
@@ -606,7 +630,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": ">=5.3.3"
@@ -653,7 +683,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": ">=5.3.3"
@@ -694,7 +730,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^5.3.3 || ^7.0"
@@ -743,7 +785,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
                 "reference": "791198a2c6254db10131eecfe8c06670700904db",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "ext-tokenizer": "*",
@@ -936,7 +984,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^5.6 || ^7.0"
@@ -981,7 +1035,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0",
@@ -1045,7 +1105,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0"
@@ -1097,7 +1163,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0"
@@ -1214,7 +1286,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0"
@@ -1265,7 +1343,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0",
@@ -1312,7 +1396,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
                 "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0"
@@ -1357,7 +1447,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
                 "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": "^7.0"
@@ -1410,7 +1506,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": ">=5.6.0"
@@ -1452,7 +1554,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "shasum": ""
+                "shasum": "",
+                "mirrors": [
+                    {
+                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
+                        "preferred": true
+                    }
+                ]
             },
             "require": {
                 "php": ">=5.6"
@@ -1747,6 +1855,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.0"
+    },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "58aabf6d7998ff09932fa350783e899e",
+    "content-hash": "abaf70a3772e4af8daa1dae79ec9a44a",
     "packages": [],
     "packages-dev": [
         {
@@ -19,13 +19,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/mikeerickson/phpunit-pretty-result-printer/zipball/ce3b989eeb6d2b8cab367897275e120520bdca18",
                 "reference": "ce3b989eeb6d2b8cab367897275e120520bdca18",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "hassankhan/config": "^0.10.0",
@@ -63,33 +57,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -102,7 +92,7 @@
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -114,12 +104,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "hassankhan/config",
@@ -133,13 +123,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/hassankhan/config/zipball/06ac500348af033f1a2e44dc357ca86282626d4a",
                 "reference": "06ac500348af033f1a2e44dc357ca86282626d4a",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
@@ -186,31 +170,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -221,7 +202,7 @@
                     "src/DeepCopy/deep_copy.php"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -233,7 +214,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-08-09T12:45:53+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -247,13 +228,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
                 "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
@@ -308,13 +283,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
                 "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
@@ -351,44 +320,36 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -407,36 +368,30 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
+                "doctrine/instantiator": "^1.0.5",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.4"
             },
@@ -453,7 +408,7 @@
                     ]
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -464,50 +419,43 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30T07:14:17+00:00"
+            "time": "2019-09-12T14:27:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -517,51 +465,46 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -586,27 +529,21 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2019-10-03T11:07:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
@@ -637,7 +574,7 @@
                     "src/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -655,7 +592,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -669,13 +606,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
@@ -722,13 +653,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
@@ -769,13 +694,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0"
@@ -824,13 +743,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
                 "reference": "791198a2c6254db10131eecfe8c06670700904db",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
@@ -869,23 +782,17 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.7",
+            "version": "6.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
@@ -902,7 +809,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -937,7 +844,7 @@
                     "src/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -955,27 +862,21 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-26T07:01:09+00:00"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
@@ -987,7 +888,7 @@
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1003,7 +904,7 @@
                     "src/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -1020,7 +921,8 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "abandoned": true,
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1034,13 +936,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
@@ -1085,13 +981,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0",
@@ -1155,13 +1045,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0"
@@ -1213,13 +1097,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0"
@@ -1259,23 +1137,17 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0",
@@ -1296,11 +1168,15 @@
                     "src/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1310,16 +1186,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1328,7 +1200,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1342,13 +1214,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0"
@@ -1399,13 +1265,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0",
@@ -1452,13 +1312,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
                 "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0"
@@ -1503,13 +1357,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
                 "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.0"
@@ -1562,13 +1410,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.6.0"
@@ -1610,13 +1452,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.6"
@@ -1648,27 +1484,131 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.0.4",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-10-28T04:36:32+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "324cf4b19c345465fad14f3602050519e09e361d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/324cf4b19c345465fad14f3602050519e09e361d",
+                "reference": "324cf4b19c345465fad14f3602050519e09e361d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -1682,7 +1622,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1693,7 +1633,7 @@
                     "/Tests/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1709,27 +1649,21 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-21T19:06:11+00:00"
+            "time": "2019-10-30T12:58:49+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
@@ -1743,7 +1677,7 @@
                     "src/"
                 ]
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -1755,34 +1689,28 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://repo.packagist.com/rexsoftware/dists/%package%/%version%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -1795,7 +1723,7 @@
                     "Webmozart\\Assert\\": "src/"
                 }
             },
-            "notification-url": "https://repo.packagist.com/rexsoftware/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1811,7 +1739,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="RexPSR2Standard">
+    <description>Rex PSR2 Standard</description>
+    <arg name="colors"/>
+
+    <!-- check directories -->
+    <file>src</file>
+    <file>tests</file>
+
+    <!-- start with psr2 -->
+    <rule ref="PSR2"/>
+
+    <!-- allow snake case for test methods -->
+    <rule ref="PSR1.Methods.CamelCapsMethodName">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+</ruleset>

--- a/src/Compositor/CompositorInterface.php
+++ b/src/Compositor/CompositorInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Compositor;
+
+interface CompositorInterface
+{
+    /**
+     * Compose included item by assigning data from current scope to the
+     * transformed root or parent node.
+     *
+     * If the parent scope is a collection parent data is from one transformed
+     * node of the collection.
+     *
+     * Order of include tree operations:
+     *   - all nodes transformed
+     *   - leaf scope serialized
+     *   - leaf scope composed with parent / root node
+     *   - parent scope serialized (will combine collection nodes)
+     *   - repeat
+     *
+     * @param array      $rootData    Mutate to add data to root node (not yet serialized)
+     * @param array      $parentData  Mutate to add data to parent node (not yet serialized)
+     * @param string     $key         Include key for this nested resource
+     * @param array|null $itemData    Serialized scope data
+     * @return void
+     */
+    public function composeIncludedItem(
+        array &$rootData,
+        array &$parentData,
+        string $key,
+        $itemData
+    );
+
+    /**
+     * Compose included collection by assigning data from current scope to the
+     * transformed root or parent node.
+     *
+     * If the parent scope is a collection parent data is from one transformed
+     * node of the collection.
+     *
+     * Order of include tree operations:
+     *   - all nodes transformed
+     *   - leaf scope serialized
+     *   - leaf scope composed with parent / root node
+     *   - parent scope serialized (will combine collection nodes)
+     *   - repeat
+     *
+     * @param array      $rootData       Mutate to add data to root node (not yet serialized)
+     * @param array      $parentData     Mutate to add data to parent node (not yet serialized)
+     * @param string     $key            Include key for this nested resource
+     * @param array|null $collectionData Serialized scope data
+     * @return void
+     */
+    public function composeIncludedCollection(
+        array &$rootData,
+        array &$parentData,
+        string $key,
+        $collectionData
+    );
+}

--- a/src/Compositor/CompositorInterface.php
+++ b/src/Compositor/CompositorInterface.php
@@ -18,10 +18,11 @@ interface CompositorInterface
      *   - parent scope serialized (will combine collection nodes)
      *   - repeat
      *
-     * @param array      $rootData    Mutate to add data to root node (not yet serialized)
-     * @param array      $parentData  Mutate to add data to parent node (not yet serialized)
-     * @param string     $key         Include key for this nested resource
-     * @param array|null $itemData    Serialized scope data
+     * @param array      $rootData   Mutate to add data to root node (not yet serialized)
+     * @param array      $parentData Mutate to add data to parent node (not yet serialized)
+     * @param string     $key        Include key for this nested resource
+     * @param array|null $itemData   Serialized scope data
+     *
      * @return void
      */
     public function composeIncludedItem(
@@ -49,6 +50,7 @@ interface CompositorInterface
      * @param array      $parentData     Mutate to add data to parent node (not yet serialized)
      * @param string     $key            Include key for this nested resource
      * @param array|null $collectionData Serialized scope data
+     *
      * @return void
      */
     public function composeIncludedCollection(

--- a/src/Compositor/DefaultCompositor.php
+++ b/src/Compositor/DefaultCompositor.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Compositor;
+
+/**
+ * Class DefaultCompositor
+ *
+ * @package Rexlabs\Smokescreen\Compositor
+ */
+class DefaultCompositor implements CompositorInterface
+{
+    /**
+     * Compose included item by assigning data from current scope to the
+     * transformed root or parent node.
+     *
+     * If the parent scope is a collection parent data is from one transformed
+     * node of the collection.
+     *
+     * Order of include tree operations:
+     *   - all nodes transformed
+     *   - leaf scope serialized
+     *   - leaf scope composed with parent / root node
+     *   - parent scope serialized (will combine collection nodes)
+     *   - repeat
+     *
+     * @param array      $rootData   Mutate to add data to root node (not yet serialized)
+     * @param array      $parentData Mutate to add data to parent node (not yet serialized)
+     * @param string     $key        Include key for this nested resource
+     * @param array|null $itemData   Serialized scope data
+     * @return void
+     */
+    public function composeIncludedItem(array &$rootData, array &$parentData, string $key, $itemData)
+    {
+        $parentData[$key] = $itemData;
+    }
+
+    /**
+     * Compose included collection by assigning data from current scope to the
+     * transformed root or parent node.
+     *
+     * If the parent scope is a collection parent data is from one transformed
+     * node of the collection.
+     *
+     * Order of include tree operations:
+     *   - all nodes transformed
+     *   - leaf scope serialized
+     *   - leaf scope composed with parent / root node
+     *   - parent scope serialized (will combine collection nodes)
+     *   - repeat
+     *
+     * @param array      $rootData       Mutate to add data to root node (not yet serialized)
+     * @param array      $parentData     Mutate to add data to parent node (not yet serialized)
+     * @param string     $key            Include key for this nested resource
+     * @param array|null $collectionData Serialized scope data
+     * @return void
+     */
+    public function composeIncludedCollection(array &$rootData, array &$parentData, string $key, $collectionData)
+    {
+        $parentData[$key] = $collectionData;
+    }
+}

--- a/src/Compositor/DefaultCompositor.php
+++ b/src/Compositor/DefaultCompositor.php
@@ -3,9 +3,7 @@
 namespace Rexlabs\Smokescreen\Compositor;
 
 /**
- * Class DefaultCompositor
- *
- * @package Rexlabs\Smokescreen\Compositor
+ * Class DefaultCompositor.
  */
 class DefaultCompositor implements CompositorInterface
 {
@@ -27,6 +25,7 @@ class DefaultCompositor implements CompositorInterface
      * @param array      $parentData Mutate to add data to parent node (not yet serialized)
      * @param string     $key        Include key for this nested resource
      * @param array|null $itemData   Serialized scope data
+     *
      * @return void
      */
     public function composeIncludedItem(array &$rootData, array &$parentData, string $key, $itemData)
@@ -52,6 +51,7 @@ class DefaultCompositor implements CompositorInterface
      * @param array      $parentData     Mutate to add data to parent node (not yet serialized)
      * @param string     $key            Include key for this nested resource
      * @param array|null $collectionData Serialized scope data
+     *
      * @return void
      */
     public function composeIncludedCollection(array &$rootData, array &$parentData, string $key, $collectionData)

--- a/src/Definition/AbstractDefinition.php
+++ b/src/Definition/AbstractDefinition.php
@@ -71,7 +71,7 @@ class AbstractDefinition
      *
      * @return bool
      */
-    public function has(string $directive)
+    public function has(string $directive): bool
     {
         return array_key_exists($directive, $this->definition);
     }

--- a/src/Exception/InvalidCompositorException.php
+++ b/src/Exception/InvalidCompositorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Exception;
+
+use InvalidArgumentException;
+
+class InvalidCompositorException extends InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidSerializerException.php
+++ b/src/Exception/InvalidSerializerException.php
@@ -2,6 +2,22 @@
 
 namespace Rexlabs\Smokescreen\Exception;
 
-class InvalidSerializerException extends \InvalidArgumentException
+use InvalidArgumentException;
+use Throwable;
+
+class InvalidSerializerException extends InvalidArgumentException
 {
+    const MESSAGE = 'Serializer must be one of: callable, SerializerInterface, false or null';
+
+    /**
+     * InvalidSerializerException constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Throwable|null $previous
+     */
+    public function __construct($message = self::MESSAGE, $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Exception/InvalidTransformerException.php
+++ b/src/Exception/InvalidTransformerException.php
@@ -2,6 +2,22 @@
 
 namespace Rexlabs\Smokescreen\Exception;
 
-class InvalidTransformerException extends \InvalidArgumentException
+use InvalidArgumentException;
+use Throwable;
+
+class InvalidTransformerException extends InvalidArgumentException
 {
+    const DEFAULT_MESSAGE = 'Transformer must be a callable or implement TransformerInterface';
+
+    /**
+     * InvalidTransformerException constructor.
+     *
+     * @param string         $message
+     * @param int            $code
+     * @param Throwable|null $previous
+     */
+    public function __construct($message = '', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message ?: self::DEFAULT_MESSAGE, $code, $previous);
+    }
 }

--- a/src/Exception/UnhandledResourceType.php
+++ b/src/Exception/UnhandledResourceType.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rexlabs\Smokescreen\Exception;
-
-class UnhandledResourceType extends \RuntimeException
-{
-}

--- a/src/Exception/UnhandledResourceTypeException.php
+++ b/src/Exception/UnhandledResourceTypeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Exception;
+
+class UnhandledResourceTypeException extends \RuntimeException
+{
+}

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -12,7 +12,7 @@ class ArrayHelper
      *
      * @param array  $array
      * @param string $readKey
-     * @param mixed $defaultValue
+     * @param mixed  $defaultValue
      *
      * @return mixed
      */
@@ -34,22 +34,22 @@ class ArrayHelper
 
         return $value;
     }
-    
+
     /**
      * Mutate an array using dot-notation.
      *
      * @param array  $array
      * @param string $writeKey
      * @param mixed  $value
-     * @param bool   $append Append value to array at write key
+     * @param bool   $append   Append value to array at write key
      *
      * @return void
      */
     public static function mutate(
-        array &$array, 
-        string $writeKey, 
-        $value, bool 
-        $append = false
+        array &$array,
+        string $writeKey,
+        $value,
+        bool $append = false
     ) {
         $ref = &$array;
         $keys = explode('.', $writeKey);

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -2,25 +2,61 @@
 
 namespace Rexlabs\Smokescreen\Helpers;
 
+use function array_key_exists;
+use function is_array;
+
 class ArrayHelper
 {
+    /**
+     * Get an array value using dot-notation.
+     *
+     * @param array  $array
+     * @param string $readKey
+     * @param mixed $defaultValue
+     *
+     * @return mixed
+     */
+    public static function get(array $array, string $readKey, $defaultValue = null)
+    {
+        $value = $array;
+        foreach (explode('.', $readKey) as $key) {
+            if (!is_array($value) || !isset($value[$key])) {
+                $value = null;
+                break;
+            }
+            $value = $value[$key];
+        }
+
+        //Get a default value
+        if ($value === null && $defaultValue !== null) {
+            return $defaultValue;
+        }
+
+        return $value;
+    }
+    
     /**
      * Mutate an array using dot-notation.
      *
      * @param array  $array
      * @param string $writeKey
      * @param mixed  $value
+     * @param bool   $append Append value to array at write key
      *
      * @return void
      */
-    public static function mutate(array &$array, string $writeKey, $value)
-    {
+    public static function mutate(
+        array &$array, 
+        string $writeKey, 
+        $value, bool 
+        $append = false
+    ) {
         $ref = &$array;
         $keys = explode('.', $writeKey);
         while (($key = array_shift($keys)) !== null) {
-            $hasMoreKeys = \count($keys) > 0;
+            $hasMoreKeys = count($keys) > 0;
             if ($hasMoreKeys) {
-                if (!\array_key_exists($key, $ref)) {
+                if (!array_key_exists($key, $ref)) {
                     // Prepare the array
                     $ref[$key] = [];
                 }
@@ -29,7 +65,11 @@ class ArrayHelper
             }
 
             // Last key
-            $ref[$key] = $value;
+            if ($append) {
+                $ref[$key][] = $value;
+            } else {
+                $ref[$key] = $value;
+            }
         }
     }
 }

--- a/src/Helpers/JsonHelper.php
+++ b/src/Helpers/JsonHelper.php
@@ -12,7 +12,7 @@ class JsonHelper
      * @param mixed $data
      * @param int   $options
      *
-     * @throws \Rexlabs\Smokescreen\Exception\JsonEncodeException
+     * @throws JsonEncodeException
      *
      * @return string
      */

--- a/src/Includes/IncludeDefinition.php
+++ b/src/Includes/IncludeDefinition.php
@@ -2,8 +2,8 @@
 
 namespace Rexlabs\Smokescreen\Includes;
 
-use function is_array;
 use Rexlabs\Smokescreen\Definition\AbstractDefinition;
+use function is_array;
 
 class IncludeDefinition extends AbstractDefinition
 {

--- a/src/Includes/IncludeDefinition.php
+++ b/src/Includes/IncludeDefinition.php
@@ -2,6 +2,7 @@
 
 namespace Rexlabs\Smokescreen\Includes;
 
+use function is_array;
 use Rexlabs\Smokescreen\Definition\AbstractDefinition;
 
 class IncludeDefinition extends AbstractDefinition
@@ -9,7 +10,7 @@ class IncludeDefinition extends AbstractDefinition
     public function relation(): array
     {
         $relation = $this->get('relation', []);
-        if (!\is_array($relation)) {
+        if (!is_array($relation)) {
             $relation = (array) preg_split('/\s*,\s*', $relation);
         }
 
@@ -21,7 +22,7 @@ class IncludeDefinition extends AbstractDefinition
         return $this->get('method');
     }
 
-    public function isDefault()
+    public function isDefault(): bool
     {
         return $this->has('default');
     }

--- a/src/Includes/IncludeParser.php
+++ b/src/Includes/IncludeParser.php
@@ -2,6 +2,9 @@
 
 namespace Rexlabs\Smokescreen\Includes;
 
+use Rexlabs\Smokescreen\Exception\ParseIncludesException;
+use function strlen;
+
 class IncludeParser implements IncludeParserInterface
 {
     /**
@@ -10,6 +13,7 @@ class IncludeParser implements IncludeParserInterface
      * @param string $str
      *
      * @return Includes
+     * @throws ParseIncludesException
      */
     public function parse(string $str): Includes
     {
@@ -46,7 +50,7 @@ class IncludeParser implements IncludeParserInterface
         ];
 
         // Process each character, moving through the state and build
-        while ($state['pos'] < ($len = \strlen($str))) {
+        while ($state['pos'] < ($len = strlen($str))) {
             $state['char'] = $str[$state['pos']];
             $state['len'] = $len;
 
@@ -81,13 +85,14 @@ class IncludeParser implements IncludeParserInterface
                     // Looks like it's a parameter. Eg. :limit(10)
                     // Well, if we have a buffer, then that's our parent, if we don't
                     // we will use the parent we saved when we popped the last parent state.
-                    $parentKey = !empty($state['buffer']) ?
-                        $this->prefixParentKeys($state['buffer'], $state['parent']) : $this->flattenKeys($state['prevParent']);
+                    $parentKey = !empty($state['buffer'])
+                        ? $this->prefixParentKeys($state['buffer'], $state['parent'])
+                        : $this->flattenKeys($state['prevParent']);
 
                     if (preg_match('/^:(\w+)\(([^)]+)\)/', substr($str, $state['pos']), $match)) {
                         // We have a match
                         list($param, $key, $val) = $match;
-                        $len = \strlen($param);
+                        $len = strlen($param);
 
                         // Initialise the parent key in our params associative array
                         if (!isset($state['params'][$parentKey])) {

--- a/src/Includes/IncludeParser.php
+++ b/src/Includes/IncludeParser.php
@@ -12,8 +12,9 @@ class IncludeParser implements IncludeParserInterface
      *
      * @param string $str
      *
-     * @return Includes
      * @throws ParseIncludesException
+     *
+     * @return Includes
      */
     public function parse(string $str): Includes
     {

--- a/src/Includes/Includes.php
+++ b/src/Includes/Includes.php
@@ -28,8 +28,8 @@ class Includes
     /**
      * Provide a list of keys, and optional parameters for those keys.
      *
-     * @param array $keys
-     * @param array $params
+     * @param array       $keys
+     * @param array       $params
      * @param string|null $parentKey
      */
     public function __construct(

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -177,6 +177,7 @@ abstract class AbstractResource implements ResourceInterface
     public function getRelationships(): array
     {
         $transformer = $this->getTransformer();
+
         return $transformer instanceof TransformerInterface
             ? $transformer->getRelationships()
             : [];

--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -2,13 +2,17 @@
 
 namespace Rexlabs\Smokescreen\Resource;
 
+use ArrayIterator;
+use IteratorAggregate;
 use Rexlabs\Smokescreen\Exception\ArrayConversionException;
 use Rexlabs\Smokescreen\Exception\NotIterableException;
 use Rexlabs\Smokescreen\Pagination\CursorInterface;
 use Rexlabs\Smokescreen\Pagination\PageableInterface;
 use Rexlabs\Smokescreen\Pagination\PaginatorInterface;
+use Traversable;
+use function is_array;
 
-class Collection extends AbstractResource implements PageableInterface, \IteratorAggregate
+class Collection extends AbstractResource implements PageableInterface, IteratorAggregate
 {
     /** @var PaginatorInterface */
     protected $paginator;
@@ -74,45 +78,45 @@ class Collection extends AbstractResource implements PageableInterface, \Iterato
      * Returns an Iterator (to implement the ArrayIterator) interface for
      * easily traversing a collection.
      *
-     * @throws \Rexlabs\Smokescreen\Exception\NotIterableException
+     * @throws NotIterableException
      *
-     * @return \Traversable
+     * @return Traversable
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): Traversable
     {
-        if ($this->data instanceof \ArrayIterator) {
+        if ($this->data instanceof ArrayIterator) {
             return $this->data;
         }
 
-        if ($this->data instanceof \IteratorAggregate) {
+        if ($this->data instanceof IteratorAggregate) {
             return $this->data->getIterator();
         }
 
-        if (!\is_array($this->data)) {
+        if (!is_array($this->data)) {
             throw new NotIterableException('Cannot get iterator for data');
         }
 
-        return new \ArrayIterator($this->data);
+        return new ArrayIterator($this->data);
     }
 
     /**
      * Converts the Collection data to an array.
      *
-     * @throws \Rexlabs\Smokescreen\Exception\ArrayConversionException
+     * @throws ArrayConversionException
      *
-     * @return array|\ArrayIterator|mixed|null
+     * @return array|ArrayIterator|mixed|null
      */
     public function toArray()
     {
-        if (\is_array($this->data)) {
+        if (is_array($this->data)) {
             return $this->data;
         }
 
-        if ($this->data instanceof \ArrayIterator) {
+        if ($this->data instanceof ArrayIterator) {
             return iterator_to_array($this->data, false);
         }
 
-        if ($this->data instanceof \IteratorAggregate) {
+        if ($this->data instanceof IteratorAggregate) {
             return iterator_to_array($this->data->getIterator(), false);
         }
 

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -2,6 +2,7 @@
 
 namespace Rexlabs\Smokescreen\Resource;
 
+use Rexlabs\Smokescreen\Compositor\CompositorInterface;
 use Rexlabs\Smokescreen\Serializer\SerializerInterface;
 use Rexlabs\Smokescreen\Transformer\TransformerInterface;
 
@@ -78,4 +79,25 @@ interface ResourceInterface
      * @return $this
      */
     public function setSerializer($serializer);
+
+    /**
+     * Get the compositor.
+     *
+     * @return CompositorInterface|callable|null
+     */
+    public function getCompositor();
+
+    /**
+     * @return bool
+     */
+    public function hasCompositor(): bool;
+
+    /**
+     * Set the compositor.
+     *
+     * @param CompositorInterface|callable|null
+     *
+     * @return $this
+     */
+    public function setCompositor($compositor);
 }

--- a/src/Serializer/DefaultSerializer.php
+++ b/src/Serializer/DefaultSerializer.php
@@ -67,7 +67,7 @@ class DefaultSerializer implements SerializerInterface
      *
      * @return array
      */
-    public function paginator(PaginatorInterface $paginator)
+    public function paginator(PaginatorInterface $paginator): array
     {
         $currentPage = $paginator->getCurrentPage();
         $lastPage = $paginator->getLastPage();
@@ -107,7 +107,7 @@ class DefaultSerializer implements SerializerInterface
                 'current' => $cursor->getCurrent(),
                 'prev'    => $cursor->getPrev(),
                 'next'    => $cursor->getNext(),
-                'count'   => (int) $cursor->getCount(),
+                'count'   => $cursor->getCount(),
             ],
         ];
     }

--- a/src/Smokescreen.php
+++ b/src/Smokescreen.php
@@ -30,7 +30,7 @@ class Smokescreen implements \JsonSerializable
 
     /** @var SerializerInterface|null */
     protected $serializer;
-    
+
     /** @var CompositorInterface|null */
     protected $compositor;
 
@@ -148,14 +148,14 @@ class Smokescreen implements \JsonSerializable
     /**
      * Returns an object (stdClass) representation of the transformed/serialized data.
      *
-     * @return \stdClass
      *@throws \Rexlabs\Smokescreen\Exception\UnhandledResourceTypeException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\JsonEncodeException
      * @throws \Rexlabs\Smokescreen\Exception\IncludeException
-     *
      * @throws \Rexlabs\Smokescreen\Exception\InvalidSerializerException
+     *
+     * @return \stdClass
      */
     public function toObject(): \stdClass
     {
@@ -167,14 +167,14 @@ class Smokescreen implements \JsonSerializable
      *
      * @param int $options
      *
-     * @return string
      *@throws \Rexlabs\Smokescreen\Exception\UnhandledResourceTypeException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\JsonEncodeException
      * @throws \Rexlabs\Smokescreen\Exception\IncludeException
-     *
      * @throws \Rexlabs\Smokescreen\Exception\InvalidSerializerException
+     *
+     * @return string
      */
     public function toJson($options = 0): string
     {
@@ -185,14 +185,14 @@ class Smokescreen implements \JsonSerializable
      * Output the transformed and serialized data as an array.
      * Implements PHP's JsonSerializable interface.
      *
-     * @return array
-     *
      * @throws \Rexlabs\Smokescreen\Exception\UnhandledResourceTypeException
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
      * @throws \Rexlabs\Smokescreen\Exception\IncludeException
-     *
      * @throws \Rexlabs\Smokescreen\Exception\InvalidSerializerException
+     *
+     * @return array
+     *
      * @see Smokescreen::toArray()
      */
     public function jsonSerialize(): array
@@ -203,13 +203,13 @@ class Smokescreen implements \JsonSerializable
     /**
      * Return the transformed data as an array.
      *
-     * @return array
      *@throws \Rexlabs\Smokescreen\Exception\UnhandledResourceTypeException
      * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
      * @throws \Rexlabs\Smokescreen\Exception\MissingResourceException
      * @throws \Rexlabs\Smokescreen\Exception\IncludeException
-     *
      * @throws \Rexlabs\Smokescreen\Exception\InvalidSerializerException
+     *
+     * @return array
      */
     public function toArray(): array
     {
@@ -272,6 +272,7 @@ class Smokescreen implements \JsonSerializable
 
         return $this;
     }
+
     /**
      * Set the compositor which will be used to compose included nodes.
      *

--- a/src/Transformer/AbstractTransformer.php
+++ b/src/Transformer/AbstractTransformer.php
@@ -2,11 +2,13 @@
 
 namespace Rexlabs\Smokescreen\Transformer;
 
+use InvalidArgumentException;
 use Rexlabs\Smokescreen\Exception\ParseDefinitionException;
 use Rexlabs\Smokescreen\Helpers\StrHelper;
 use Rexlabs\Smokescreen\Resource\Collection;
 use Rexlabs\Smokescreen\Resource\Item;
 use Rexlabs\Smokescreen\Transformer\Props\DeclarativeProps;
+use function is_int;
 
 class AbstractTransformer implements TransformerInterface
 {
@@ -66,7 +68,7 @@ class AbstractTransformer implements TransformerInterface
         $map = [];
 
         foreach ($this->includes as $includeKey => $definition) {
-            if (\is_int($includeKey)) {
+            if (is_int($includeKey)) {
                 $includeKey = $definition;
                 $definition = null;
             }
@@ -144,12 +146,13 @@ class AbstractTransformer implements TransformerInterface
      */
     public function getRelationships(): array
     {
-        return array_column(
-            array_filter(array_map(function ($includeKey, $settings) {
+        return array_column(array_filter(array_map(
+            function ($includeKey, $settings) {
                 return $settings['relation'] ? [$includeKey, $settings['relation']] : null;
-            }, array_keys($this->getIncludeMap()), array_values($this->getIncludeMap()))),
-            1, 0
-        );
+            },
+            array_keys($this->getIncludeMap()),
+            array_values($this->getIncludeMap())
+        )), 1, 0);
     }
 
     /**
@@ -199,7 +202,7 @@ class AbstractTransformer implements TransformerInterface
     /**
      * @param $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return array
      */

--- a/src/Transformer/Node.php
+++ b/src/Transformer/Node.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Transformer;
+
+use Rexlabs\Smokescreen\Resource\ResourceInterface;
+
+/**
+ * Class Node
+ *
+ * @package Rexlabs\Smokescreen\Transformer
+ */
+class Node
+{
+    /**
+     * @var Scope
+     */
+    private $containingScope;
+
+    /**
+     * @var array|null
+     */
+    private $data;
+
+    /**
+     * @var array|null
+     */
+    private $transformedData;
+
+    /**
+     * @var Scope[]
+     */
+    private $includedScopes;
+
+    /**
+     * Node constructor.
+     *
+     * @param Scope $containingScope
+     * @param array|null $data Subset of resource data eg 1 item of a collection
+     */
+    public function __construct(Scope $containingScope, $data)
+    {
+        $this->containingScope = $containingScope;
+        $this->data            = $data;
+        $this->includedScopes  = [];
+    }
+
+    /**
+     * @return Scope
+     */
+    public function getContainingScope(): Scope
+    {
+        return $this->containingScope;
+    }
+
+    /**
+     * @return mixed|ResourceInterface
+     */
+    public function getScopeResource()
+    {
+        return $this->containingScope->resource();
+    }
+
+    /**
+     * @return mixed|TransformerInterface|null
+     */
+    public function getTransformer()
+    {
+        return $this->containingScope->transformer();
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getTransformedData()
+    {
+        return $this->transformedData;
+    }
+
+    /**
+     * @param array $transformedData
+     * @return void
+     */
+    public function setTransformedData($transformedData)
+    {
+        $this->transformedData = $transformedData;
+    }
+
+    /**
+     * @return Scope[]
+     */
+    public function getIncludedScopes(): array
+    {
+        return $this->includedScopes;
+    }
+
+    /**
+     * @param Scope[] $scopes
+     * @return void
+     */
+    public function setIncludedScopes(array $scopes)
+    {
+        $this->includedScopes = $scopes;
+    }
+}

--- a/src/Transformer/Node.php
+++ b/src/Transformer/Node.php
@@ -5,9 +5,7 @@ namespace Rexlabs\Smokescreen\Transformer;
 use Rexlabs\Smokescreen\Resource\ResourceInterface;
 
 /**
- * Class Node
- *
- * @package Rexlabs\Smokescreen\Transformer
+ * Class Node.
  */
 class Node
 {
@@ -34,14 +32,14 @@ class Node
     /**
      * Node constructor.
      *
-     * @param Scope $containingScope
-     * @param array|null $data Subset of resource data eg 1 item of a collection
+     * @param Scope      $containingScope
+     * @param array|null $data            Subset of resource data eg 1 item of a collection
      */
     public function __construct(Scope $containingScope, $data)
     {
         $this->containingScope = $containingScope;
-        $this->data            = $data;
-        $this->includedScopes  = [];
+        $this->data = $data;
+        $this->includedScopes = [];
     }
 
     /**
@@ -86,6 +84,7 @@ class Node
 
     /**
      * @param array $transformedData
+     *
      * @return void
      */
     public function setTransformedData($transformedData)
@@ -103,6 +102,7 @@ class Node
 
     /**
      * @param Scope[] $scopes
+     *
      * @return void
      */
     public function setIncludedScopes(array $scopes)

--- a/src/Transformer/Pipeline.php
+++ b/src/Transformer/Pipeline.php
@@ -33,6 +33,7 @@ class Pipeline
 
     /**
      * @param TransformerResolverInterface $transformerResolver
+     *
      * @return void
      */
     public function setTransformerResolver(TransformerResolverInterface $transformerResolver)
@@ -42,6 +43,7 @@ class Pipeline
 
     /**
      * @param SerializerInterface $serializer
+     *
      * @return void
      */
     public function setSerializer(SerializerInterface $serializer)
@@ -51,6 +53,7 @@ class Pipeline
 
     /**
      * @param CompositorInterface $compositor
+     *
      * @return void
      */
     public function setCompositor(CompositorInterface $compositor)
@@ -60,6 +63,7 @@ class Pipeline
 
     /**
      * @param RelationLoaderInterface $relationLoader
+     *
      * @return void
      */
     public function setRelationLoader(RelationLoaderInterface $relationLoader)
@@ -71,11 +75,13 @@ class Pipeline
      * Run the transformation pipeline:
      *   create includes tree
      *   transform nodes
-     *   serialize and compose scopes
+     *   serialize and compose scopes.
      *
      * @param Scope $root
-     * @return array|null
+     *
      * @throws IncludeException
+     *
+     * @return array|null
      */
     public function run(Scope $root)
     {
@@ -110,7 +116,8 @@ class Pipeline
 
     /**
      * @param array|null $rootData
-     * @param array $includesData
+     * @param array      $includesData
+     *
      * @return array|null
      */
     protected function mergeRoot($rootData, array $includesData)
@@ -124,6 +131,7 @@ class Pipeline
 
     /**
      * @param Node $node
+     *
      * @return void
      */
     protected function transformNode(Node $node)
@@ -137,6 +145,7 @@ class Pipeline
 
     /**
      * @param Scope $scope
+     *
      * @return void
      */
     protected function serializeScope(Scope $scope)
@@ -152,6 +161,7 @@ class Pipeline
     /**
      * @param array $rootData
      * @param Scope $scope
+     *
      * @return void
      */
     protected function composeScope(array &$rootData, Scope $scope)
@@ -188,8 +198,10 @@ class Pipeline
 
     /**
      * @param Scope $scope
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     protected function createIncludesTree(Scope $scope)
     {
@@ -200,7 +212,7 @@ class Pipeline
 
         // Add included scopes to each node
         $includeMap = $scope->includeMap();
-        foreach ((array)$scope->getNodes() as $node) {
+        foreach ((array) $scope->getNodes() as $node) {
             $node->setIncludedScopes(
                 array_map(function (string $includeKey) use ($node, $includeMap) {
                     return $this->createIncludedScope($node, $includeMap, $includeKey);
@@ -216,8 +228,10 @@ class Pipeline
 
     /**
      * @param Scope $scope
-     * @return null|Node[]
+     *
      * @throws UnhandledResourceTypeException
+     *
+     * @return null|Node[]
      */
     protected function createNodes(Scope $scope)
     {
@@ -231,7 +245,7 @@ class Pipeline
         } elseif (is_array($resource) || $resource === null) {
             $dataItems = $resource;
         } else {
-            throw new UnhandledResourceTypeException('Unable to serialize resource of type ' . gettype($resource));
+            throw new UnhandledResourceTypeException('Unable to serialize resource of type '.gettype($resource));
         }
 
         // Only collections have multiple nodes per scope
@@ -249,6 +263,7 @@ class Pipeline
         foreach ($dataItems as $dataItem) {
             $nodes[] = new Node($scope, $dataItem);
         }
+
         return $nodes;
     }
 
@@ -256,8 +271,10 @@ class Pipeline
      * @param Node   $node
      * @param array  $includeMap
      * @param string $includeKey
-     * @return Scope
+     *
      * @throws IncludeException
+     *
+     * @return Scope
      */
     protected function createIncludedScope(
         Node $node,
@@ -282,6 +299,7 @@ class Pipeline
 
     /**
      * @param Scope $scope
+     *
      * @return void
      */
     protected function prepareScopeResource(Scope $scope)
@@ -303,10 +321,11 @@ class Pipeline
     }
 
     /**
-     * Serialize the data
+     * Serialize the data.
+     *
      * @param ResourceInterface|mixed|null $resource
-     * @param array|null $data
-     * @param string|null $includeKey
+     * @param array|null                   $data
+     * @param string|null                  $includeKey
      *
      * @return array|mixed
      */
@@ -333,7 +352,7 @@ class Pipeline
             // Serialize via a callable/closure
             return $serializer($includeKey, $data);
         }
-       
+
         return $data;
     }
 
@@ -341,7 +360,8 @@ class Pipeline
      * @param SerializerInterface $serializer
      * @param Collection          $resource
      * @param                     $data
-     * @param  string|null        $includeKey
+     * @param string|null         $includeKey
+     *
      * @return mixed
      */
     protected function serializeCollection(
@@ -357,6 +377,7 @@ class Pipeline
         if ($resource->hasPaginator()) {
             $data = array_merge($data, $serializer->paginator($resource->getPaginator()));
         }
+
         return $data;
     }
 
@@ -364,6 +385,7 @@ class Pipeline
      * @param SerializerInterface $serializer
      * @param array|null          $data
      * @param string|null         $includeKey
+     *
      * @return array|mixed
      */
     protected function serializeItem(

--- a/src/Transformer/Pipeline.php
+++ b/src/Transformer/Pipeline.php
@@ -2,74 +2,293 @@
 
 namespace Rexlabs\Smokescreen\Transformer;
 
+use ArrayAccess;
+use Rexlabs\Smokescreen\Compositor\CompositorInterface;
+use Rexlabs\Smokescreen\Compositor\DefaultCompositor;
 use Rexlabs\Smokescreen\Exception\IncludeException;
 use Rexlabs\Smokescreen\Exception\InvalidTransformerException;
-use Rexlabs\Smokescreen\Exception\UnhandledResourceType;
-use Rexlabs\Smokescreen\Helpers\ArrayHelper;
+use Rexlabs\Smokescreen\Exception\UnhandledResourceTypeException;
 use Rexlabs\Smokescreen\Relations\RelationLoaderInterface;
 use Rexlabs\Smokescreen\Resource\Collection;
 use Rexlabs\Smokescreen\Resource\Item;
 use Rexlabs\Smokescreen\Resource\ResourceInterface;
 use Rexlabs\Smokescreen\Serializer\SerializerInterface;
+use function is_array;
+use function is_callable;
+use function is_object;
 
 class Pipeline
 {
-    /** @var SerializerInterface */
+    /** @var SerializerInterface|null */
     protected $serializer;
 
-    /** @var TransformerResolverInterface|null */
-    protected $transformerResolver;
+    /** @var CompositorInterface|null */
+    protected $compositor;
 
     /** @var RelationLoaderInterface|null */
     protected $relationLoader;
 
-    public function __construct()
-    {
-    }
+    /** @var TransformerResolverInterface|null */
+    protected $transformerResolver;
 
+    /**
+     * @param TransformerResolverInterface $transformerResolver
+     * @return void
+     */
     public function setTransformerResolver(TransformerResolverInterface $transformerResolver)
     {
         $this->transformerResolver = $transformerResolver;
     }
 
+    /**
+     * @param SerializerInterface $serializer
+     * @return void
+     */
     public function setSerializer(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;
     }
 
+    /**
+     * @param CompositorInterface $compositor
+     * @return void
+     */
+    public function setCompositor(CompositorInterface $compositor)
+    {
+        $this->compositor = $compositor;
+    }
+
+    /**
+     * @param RelationLoaderInterface $relationLoader
+     * @return void
+     */
     public function setRelationLoader(RelationLoaderInterface $relationLoader)
     {
         $this->relationLoader = $relationLoader;
     }
 
     /**
-     * @param Scope $scope
+     * Run the transformation pipeline:
+     *   create includes tree
+     *   transform nodes
+     *   serialize and compose scopes
      *
+     * @param Scope $root
+     * @return array|null
      * @throws IncludeException
-     *
+     */
+    public function run(Scope $root)
+    {
+        $this->createIncludesTree($root);
+
+        // Transform all nodes
+        foreach ($root->nodeTraversal() as $node) {
+            $this->transformNode($node);
+        }
+
+        /*
+         * Serialise and compose all scopes
+         *
+         * Serializing often nests the transformed data in a "data" node
+         * This can make it difficult to compose child nodes onto a parent
+         * Issue is avoided by traversing depth first (post-order)
+         *  1. leaf scope is searialized
+         *  2. leaf scope composed with unserialized parent node / root node
+         *  3. parent scope serialized
+         */
+        $rootData = [];
+        foreach ($root->scopeTraversal() as $scope) {
+            // Serialize first
+            $this->serializeScope($scope);
+
+            // Compose, optionally attaching to transformed (but not yet serialized) node
+            $this->composeScope($rootData, $scope);
+        }
+
+        return $this->mergeRoot($root->getSerializedData(), $rootData);
+    }
+
+    /**
+     * @param array|null $rootData
+     * @param array $includesData
      * @return array|null
      */
-    public function transform(Scope $scope)
+    protected function mergeRoot($rootData, array $includesData)
+    {
+        if (!is_array($rootData)) {
+            return $rootData;
+        }
+
+        return array_merge($rootData, $includesData);
+    }
+
+    /**
+     * @param Node $node
+     * @return void
+     */
+    protected function transformNode(Node $node)
+    {
+        $transformedData = $this->transform(
+            $node->getContainingScope(),
+            $node->getData()
+        );
+        $node->setTransformedData($transformedData);
+    }
+
+    /**
+     * @param Scope $scope
+     * @return void
+     */
+    protected function serializeScope(Scope $scope)
+    {
+        $serializedData = $this->serialize(
+            $scope->resource(),
+            $scope->getTransformedData(),
+            $scope->includeKey()
+        );
+        $scope->setSerializedData($serializedData);
+    }
+
+    /**
+     * @param array $rootData
+     * @param Scope $scope
+     * @return void
+     */
+    protected function composeScope(array &$rootData, Scope $scope)
+    {
+        $parent = $scope->parent();
+        $key = $scope->includeKey();
+
+        // Skip the root node
+        if ($parent === null || $key === null) {
+            return;
+        }
+
+        $compositor = $scope->getResourceCompositor()
+            ?? $this->compositor
+            ?? new DefaultCompositor();
+
+        // Take current scope's serialized data and
+        // apply it to parent node's transformed data
+        $parentData = $parent->getTransformedData() ?? [];
+        $data = $scope->getSerializedData();
+
+        if ($compositor instanceof CompositorInterface) {
+            if ($scope->isCollection()) {
+                $compositor->composeIncludedCollection($rootData, $parentData, $key, $data);
+            } else {
+                $compositor->composeIncludedItem($rootData, $parentData, $key, $data);
+            }
+        } elseif (is_callable($compositor)) {
+            $compositor($rootData, $parentData, $key, $data);
+        }
+
+        $parent->setTransformedData($parentData);
+    }
+
+    /**
+     * @param Scope $scope
+     * @return void
+     * @throws IncludeException
+     */
+    protected function createIncludesTree(Scope $scope)
+    {
+        $this->prepareScopeResource($scope);
+
+        // Create one (item) or many (collection) nodes
+        $scope->setNodes($this->createNodes($scope));
+
+        // Add included scopes to each node
+        $includeMap = $scope->includeMap();
+        foreach ((array)$scope->getNodes() as $node) {
+            $node->setIncludedScopes(
+                array_map(function (string $includeKey) use ($node, $includeMap) {
+                    return $this->createIncludedScope($node, $includeMap, $includeKey);
+                }, $scope->resolvedIncludeKeys())
+            );
+        }
+
+        // Recursively create nested nodes and scopes
+        foreach ($scope->getIncludedScopes() as $includedScope) {
+            $this->createIncludesTree($includedScope);
+        }
+    }
+
+    /**
+     * @param Scope $scope
+     * @return null|Node[]
+     * @throws UnhandledResourceTypeException
+     */
+    protected function createNodes(Scope $scope)
     {
         $resource = $scope->resource();
-        
-        // When we encounter a null resource, we just return null because
-        // there's nothing else we can do with it.
-        if ($resource === null) {
+
+        // Get raw data for nodes in this scope
+        if ($resource instanceof ResourceInterface) {
+            $dataItems = $resource->getData();
+        } elseif (is_object($resource) && method_exists($resource, 'toArray')) {
+            $dataItems = $resource->toArray();
+        } elseif (is_array($resource) || $resource === null) {
+            $dataItems = $resource;
+        } else {
+            throw new UnhandledResourceTypeException('Unable to serialize resource of type ' . gettype($resource));
+        }
+
+        // Only collections have multiple nodes per scope
+        if (!$resource instanceof Collection) {
+            $dataItems = [$dataItems];
+        }
+
+        // Null collection stay null
+        if ($dataItems === null) {
             return null;
         }
-        
-        // If the resource is not a ResourceInterface instance we allow it to be
-        // something array-like.
-        if (!($resource instanceof ResourceInterface)) {
-            if (\is_array($resource)) {
-                return $resource;
-            }
-            if (\is_object($resource) && method_exists($resource, 'toArray')) {
-                return $resource->toArray();
-            }
 
-            throw new UnhandledResourceType('Unable to serialize resource of type ' . \gettype($resource));
+        // Use foreach instead of array_map to support traversable collections
+        $nodes = [];
+        foreach ($dataItems as $dataItem) {
+            $nodes[] = new Node($scope, $dataItem);
+        }
+        return $nodes;
+    }
+
+    /**
+     * @param Node   $node
+     * @param array  $includeMap
+     * @param string $includeKey
+     * @return Scope
+     * @throws IncludeException
+     */
+    protected function createIncludedScope(
+        Node $node,
+        array $includeMap,
+        string $includeKey
+    ): Scope {
+        $childResource = $this->executeTransformerInclude(
+            $node->getContainingScope(),
+            $includeKey,
+            $includeMap[$includeKey],
+            $node->getData()
+        );
+        $includes = $node->getContainingScope()->includes()->splice($includeKey);
+
+        // If working with a ResourceInterface, use it's own key (if present).
+        $childKey = $childResource instanceof ResourceInterface && $childResource->getResourceKey()
+            ? $childResource->getResourceKey()
+            : $includeKey;
+
+        return new Scope($childResource, $includes, $node, $childKey);
+    }
+
+    /**
+     * @param Scope $scope
+     * @return void
+     */
+    protected function prepareScopeResource(Scope $scope)
+    {
+        $resource = $scope->resource();
+        if (!$resource instanceof ResourceInterface) {
+            return;
         }
 
         // Try to resolve a transformer for a resource that does not have one
@@ -81,58 +300,80 @@ class Pipeline
 
         // Call the relationship loader for any relations
         $this->loadRelations($resource, $scope->resolvedRelationshipKeys());
-
-        // We can only transform the resource data if we have some data to
-        // transform ...
-        if (($data = $resource->getData()) !== null) {
-            // Build the data by recursively transforming each resource.
-            if ($resource instanceof Collection) {
-                $data = [];
-                foreach ($resource as $itemData) {
-                    $data[] = $this->transformData($scope, $itemData);
-                }
-            } elseif ($resource instanceof Item) {
-                $data = $this->transformData($scope, $data);
-            }
-        }
-
-        // Serialize the transformed data
-        return $this->serialize($resource, $data);
     }
 
     /**
      * Serialize the data
-     * @param ResourceInterface $resource
-     * @param                   $data
+     * @param ResourceInterface|mixed|null $resource
+     * @param array|null $data
+     * @param string|null $includeKey
      *
      * @return array|mixed
      */
-    protected function serialize(ResourceInterface $resource, $data)
+    protected function serialize($resource, $data, $includeKey = null)
     {
         // Get the serializer from the resource, or use the default.
-        $serializer = $resource->getSerializer() ?? $this->getSerializer();
-        
+        $serializer = $resource instanceof ResourceInterface
+            ? $resource->getSerializer()
+            : null;
+        if ($serializer === null) {
+            $serializer = $this->getSerializer();
+        }
+
         if ($serializer instanceof SerializerInterface) {
             if ($resource instanceof Collection) {
-                if ($data === null) {
-                    return $serializer->nullCollection();
-                }
-                $data = $serializer->collection($resource->getResourceKey(), $data);
-                if ($resource->hasPaginator()) {
-                    $data = array_merge($data, $serializer->paginator($resource->getPaginator()));
-                }
-            } elseif ($resource instanceof Item) {
-                if ($data === null) {
-                    return $serializer->nullItem();
-                }
-                $data = $serializer->item($resource->getResourceKey(), $data);
+                return $this->serializeCollection($serializer, $resource, $data, $includeKey);
             }
-        } elseif (\is_callable($serializer)) {
+
+            if ($resource instanceof Item) {
+                return $this->serializeItem($serializer, $data, $includeKey);
+            }
+        }
+        if (is_callable($serializer)) {
             // Serialize via a callable/closure
-            $data = $serializer($resource->getResourceKey(), $data);
+            return $serializer($includeKey, $data);
         }
        
         return $data;
+    }
+
+    /**
+     * @param SerializerInterface $serializer
+     * @param Collection          $resource
+     * @param                     $data
+     * @param  string|null        $includeKey
+     * @return mixed
+     */
+    protected function serializeCollection(
+        SerializerInterface $serializer,
+        Collection $resource,
+        $data,
+        $includeKey
+    ) {
+        if ($data === null) {
+            return $serializer->nullCollection();
+        }
+        $data = $serializer->collection($includeKey, $data);
+        if ($resource->hasPaginator()) {
+            $data = array_merge($data, $serializer->paginator($resource->getPaginator()));
+        }
+        return $data;
+    }
+
+    /**
+     * @param SerializerInterface $serializer
+     * @param array|null          $data
+     * @param string|null         $includeKey
+     * @return array|mixed
+     */
+    protected function serializeItem(
+        SerializerInterface $serializer,
+        $data,
+        $includeKey = null
+    ) {
+        return $data === null
+            ? $serializer->nullItem()
+            : $serializer->item($includeKey, $data);
     }
 
     /**
@@ -141,13 +382,15 @@ class Pipeline
      * @param Scope $scope
      * @param mixed $data
      *
-     * @throws IncludeException
-     *
-     * @return array
+     * @return array|null
      */
-    protected function transformData(Scope $scope, $data): array
+    protected function transform(Scope $scope, $data)
     {
         $transformer = $scope->transformer();
+
+        if ($data === null) {
+            return null;
+        }
 
         // Handle when no transformer is present
         if (empty($transformer)) {
@@ -156,7 +399,7 @@ class Pipeline
         }
 
         // Handle when transformer is a callable
-        if (\is_callable($transformer)) {
+        if (is_callable($transformer)) {
             // Simply run callable on the data and return the result
             return (array) $transformer($data);
         }
@@ -167,28 +410,7 @@ class Pipeline
         }
 
         // Transform the data, and filter any sparse field-set for the scope.
-        $transformedData = $scope->filterData($transformer->getTransformedData($data));
-
-        // Add includes to the payload.
-        $includeMap = $scope->includeMap();
-        foreach ($scope->resolvedIncludeKeys() as $includeKey) {
-            $child = $this->executeTransformerInclude($scope, $includeKey, $includeMap[$includeKey], $data);
-
-            // Create a new child scope.
-            $childScope = new Scope($child, $scope->includes()->splice($includeKey), $scope);
-
-            // If working with a ResourceInterface, use it's own key (if present).
-            $childKey = $child instanceof ResourceInterface && $child->getResourceKey() ?
-                $child->getResourceKey() : $includeKey;
-
-            ArrayHelper::mutate(
-                $transformedData,
-                $childKey,
-                $this->transform($childScope)
-            );
-        }
-
-        return $transformedData;
+        return $scope->filterData($transformer->getTransformedData($data));
     }
 
     /**
@@ -201,10 +423,14 @@ class Pipeline
      *
      * @throws IncludeException
      *
-     * @return ResourceInterface
+     * @return ResourceInterface|mixed
      */
-    protected function executeTransformerInclude(Scope $scope, $includeKey, $includeDefinition, $data)
-    {
+    protected function executeTransformerInclude(
+        Scope $scope,
+        $includeKey,
+        $includeDefinition,
+        $data
+    ) {
         // Transformer explicitly provided an include method
         $transformer = $scope->transformer();
         $method = $includeDefinition['method'];
@@ -253,8 +479,7 @@ class Pipeline
      * @param array  $includeDefinition
      * @param        $item
      *
-     * @throws \Rexlabs\Smokescreen\Exception\InvalidTransformerException
-     * @throws \Rexlabs\Smokescreen\Exception\IncludeException
+     * @throws IncludeException
      *
      * @return Collection|Item|ResourceInterface
      */
@@ -262,12 +487,12 @@ class Pipeline
     {
         // Get the included data
         $data = null;
-        if (\is_array($item) || $item instanceof \ArrayAccess) {
+        if (is_array($item) || $item instanceof ArrayAccess) {
             $data = $item[$includeKey] ?? null;
-        } elseif (\is_object($item)) {
+        } elseif (is_object($item)) {
             $data = $item->$includeKey ?? null;
         } else {
-            throw new IncludeException("Cannot auto-wire include for $includeKey: Cannot get include data");
+            throw new IncludeException("Cannot auto-wire include for {$includeKey}: Cannot get include data");
         }
 
         if (!empty($includeDefinition['resource_type']) && $includeDefinition['resource_type'] === 'collection') {
@@ -278,6 +503,9 @@ class Pipeline
         return new Item($data);
     }
 
+    /**
+     * @return SerializerInterface|mixed
+     */
     protected function getSerializer()
     {
         return $this->serializer;

--- a/src/Transformer/Props/DeclarativeProps.php
+++ b/src/Transformer/Props/DeclarativeProps.php
@@ -9,13 +9,13 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
-use function is_array;
-use function is_int;
 use Rexlabs\Smokescreen\Definition\DefinitionParser;
 use Rexlabs\Smokescreen\Exception\InvalidDefinitionException;
 use Rexlabs\Smokescreen\Exception\ParseDefinitionException;
 use Rexlabs\Smokescreen\Helpers\ArrayHelper;
 use Rexlabs\Smokescreen\Helpers\StrHelper;
+use function is_array;
+use function is_int;
 
 trait DeclarativeProps
 {
@@ -75,7 +75,7 @@ trait DeclarativeProps
      * or array.
      *
      * @param ArrayAccess|array $model
-     * @param array              $props
+     * @param array             $props
      *
      * @throws InvalidArgumentException
      *
@@ -118,7 +118,7 @@ trait DeclarativeProps
 
     /**
      * @param ArrayAccess|array $model
-     * @param PropDefinition     $propDefinition
+     * @param PropDefinition    $propDefinition
      *
      * @throws InvalidArgumentException
      *

--- a/src/Transformer/Props/DeclarativeProps.php
+++ b/src/Transformer/Props/DeclarativeProps.php
@@ -2,12 +2,18 @@
 
 namespace Rexlabs\Smokescreen\Transformer\Props;
 
+use ArrayAccess;
+use Closure;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use InvalidArgumentException;
+use function is_array;
+use function is_int;
 use Rexlabs\Smokescreen\Definition\DefinitionParser;
 use Rexlabs\Smokescreen\Exception\InvalidDefinitionException;
+use Rexlabs\Smokescreen\Exception\ParseDefinitionException;
 use Rexlabs\Smokescreen\Helpers\ArrayHelper;
 use Rexlabs\Smokescreen\Helpers\StrHelper;
 
@@ -68,17 +74,17 @@ trait DeclarativeProps
      * Helper method for returning formatted properties from a source object
      * or array.
      *
-     * @param \ArrayAccess|array $model
+     * @param ArrayAccess|array $model
      * @param array              $props
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return array
      */
     protected function withProps($model, array $props): array
     {
-        if (!(\is_array($model) || $model instanceof \ArrayAccess)) {
-            throw new \InvalidArgumentException('Expect array or object implementing \ArrayAccess');
+        if (!(is_array($model) || $model instanceof ArrayAccess)) {
+            throw new InvalidArgumentException('Expect array or object implementing ArrayAccess');
         }
 
         // Given an array of props (which may include a definition value), we
@@ -86,7 +92,7 @@ trait DeclarativeProps
         // conversions to the value as necessary.
         $data = [];
         foreach ($props as $key => $definition) {
-            if (\is_int($key)) {
+            if (is_int($key)) {
                 // This isn't a key => value pair, so there is no definition.
                 $key = $definition;
                 $definition = null;
@@ -95,7 +101,7 @@ trait DeclarativeProps
             // Convert property to a snake-case version.
             // It may be a nested (dot-notation) key.
             $propKey = StrHelper::snakeCase($key);
-            if ($definition instanceof \Closure) {
+            if ($definition instanceof Closure) {
                 // If the definition is a function, execute it on the value
                 $value = $definition->bindTo($this)($model, $propKey);
             } else {
@@ -111,10 +117,10 @@ trait DeclarativeProps
     }
 
     /**
-     * @param \ArrayAccess|array $model
+     * @param ArrayAccess|array $model
      * @param PropDefinition     $propDefinition
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return mixed|null
      */
@@ -133,7 +139,7 @@ trait DeclarativeProps
      * @param mixed          $value
      * @param PropDefinition $propDefinition
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return mixed
      */
@@ -175,7 +181,6 @@ trait DeclarativeProps
             default:
                 // Fall through
                 break;
-
         }
 
         // As a final attempt, try to locate a matching method on the class that
@@ -215,7 +220,7 @@ trait DeclarativeProps
      * @param string       $propKey
      * @param string|mixed $definition
      *
-     * @throws \Rexlabs\Smokescreen\Exception\ParseDefinitionException
+     * @throws ParseDefinitionException
      *
      * @return PropDefinition
      */

--- a/src/Transformer/Scope.php
+++ b/src/Transformer/Scope.php
@@ -44,14 +44,15 @@ class Scope
         Node $parent = null,
         string $includeKey = null
     ) {
-        $this->resource   = $resource;
-        $this->includes   = $includes;
-        $this->parent     = $parent;
+        $this->resource = $resource;
+        $this->includes = $includes;
+        $this->parent = $parent;
         $this->includeKey = $includeKey;
     }
 
     /**
      * @param null|array|Node[] $nodes
+     *
      * @return void
      */
     public function setNodes($nodes)
@@ -81,11 +82,12 @@ class Scope
     public function getIncludedScopes(): array
     {
         $scopes = [];
-        foreach ((array)$this->nodes as $childNode) {
+        foreach ((array) $this->nodes as $childNode) {
             foreach ($childNode->getIncludedScopes() as $childScope) {
                 $scopes[] = $childScope;
             }
         }
+
         return $scopes;
     }
 
@@ -312,7 +314,7 @@ class Scope
      */
     public function nodeTraversal(): Generator
     {
-        foreach ((array)$this->nodes as $childNode) {
+        foreach ((array) $this->nodes as $childNode) {
             yield $childNode;
             foreach ($childNode->getIncludedScopes() as $childScope) {
                 yield from $childScope->nodeTraversal();
@@ -322,7 +324,7 @@ class Scope
 
     /**
      * Depth first traversal (post-order)
-     * All children visited before parent
+     * All children visited before parent.
      *
      *         A
      *       /  \
@@ -336,7 +338,7 @@ class Scope
      */
     public function scopeTraversal(): Generator
     {
-        foreach ((array)$this->nodes as $childNode) {
+        foreach ((array) $this->nodes as $childNode) {
             foreach ($childNode->getIncludedScopes() as $childScope) {
                 yield from $childScope->scopeTraversal();
             }
@@ -383,6 +385,7 @@ class Scope
 
     /**
      * @param array|null $serializedData
+     *
      * @return void
      */
     public function setSerializedData($serializedData)

--- a/tests/Unit/Includes/IncludesTest.php
+++ b/tests/Unit/Includes/IncludesTest.php
@@ -89,6 +89,7 @@ class IncludesTest extends TestCase
 
     /**
      * @test
+     *
      * @throws ParseIncludesException
      */
     public function can_set_params()

--- a/tests/Unit/Includes/IncludesTest.php
+++ b/tests/Unit/Includes/IncludesTest.php
@@ -87,7 +87,10 @@ class IncludesTest extends TestCase
         $this->assertFalse($includes->hasParams());
     }
 
-    /** @test */
+    /**
+     * @test
+     * @throws ParseIncludesException
+     */
     public function can_set_params()
     {
         $includes = (new IncludeParser())->parse('movies:limit(10)');

--- a/tests/Unit/Resource/AbstractResourceTest.php
+++ b/tests/Unit/Resource/AbstractResourceTest.php
@@ -187,6 +187,19 @@ class AbstractResourceTest extends TestCase
             {
                 return [];
             }
+
+            /**
+             * @param array  $rootData
+             * @param array  $parentData
+             * @param string $key
+             * @param array  $data
+             *
+             * @return void
+             */
+            public function composeIncludedData(array &$rootData, array &$parentData, string $key, array $data)
+            {
+                // TODO: Implement composeIncludedData() method.
+            }
         };
     }
 }

--- a/tests/Unit/SmokescreenTest.php
+++ b/tests/Unit/SmokescreenTest.php
@@ -151,6 +151,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_set_item_transformer_to_closure()
@@ -191,6 +192,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function invalid_json_throws_exception()
@@ -207,6 +209,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function cannot_export_array_without_resource()
@@ -217,9 +220,10 @@ class SmokescreenTest extends TestCase
     }
 
     /**
-     * Test that a custom include method is called on the transformer
+     * Test that a custom include method is called on the transformer.
      *
      * @test
+     *
      * @throws IncludeException
      */
     public function custom_include_method_used()
@@ -267,6 +271,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_output_object()
@@ -291,6 +296,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function transformer_should_not_be_required()
@@ -310,6 +316,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function resource_can_override_serializer()
@@ -382,6 +389,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function include_can_return_array_instead_of_resource()
@@ -440,6 +448,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_serialize_an_object_with_to_array_method()
@@ -464,6 +473,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function serialize_object_without_array_method_throws_exception()
@@ -476,8 +486,10 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     public function serialize_string_throws_exception()
     {
@@ -489,6 +501,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_serialize_collection_with_a_closure()
@@ -519,6 +532,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_serialize_item_with_a_closure()
@@ -537,6 +551,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function setting_serializer_to_false_on_resource_disables_serialization()
@@ -571,6 +586,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function does_trigger_relationship_loading()
@@ -602,7 +618,7 @@ class SmokescreenTest extends TestCase
         ], $transformer);
 
         /**
-         * @var RelationLoaderInterface|MockObject $relationLoader
+         * @var RelationLoaderInterface|MockObject
          */
         $relationLoader = $this->getMockBuilder(RelationLoaderInterface::class)->setMethods(['load'])->getMock();
 
@@ -619,6 +635,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function only_default_props_are_returned()
@@ -681,6 +698,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_autowire_include()
@@ -706,8 +724,10 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     public function null_item_transforms_to_empty_array()
     {
@@ -722,8 +742,10 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     public function null_collection_transforms_to_empty_array()
     {
@@ -738,8 +760,10 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     public function null_item_can_include()
     {
@@ -762,6 +786,7 @@ class SmokescreenTest extends TestCase
 
     /**
      * @test
+     *
      * @throws IncludeException
      */
     public function can_autowire_include_with_object()

--- a/tests/Unit/Transformer/PipelineTest.php
+++ b/tests/Unit/Transformer/PipelineTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Tests\Unit\Transformer;
+
+use PHPUnit\Framework\TestCase;
+use Rexlabs\Smokescreen\Exception\IncludeException;
+use Rexlabs\Smokescreen\Includes\Includes;
+use Rexlabs\Smokescreen\Transformer\Pipeline;
+use Rexlabs\Smokescreen\Transformer\Scope;
+
+/**
+ * Class PipelineTest
+ *
+ * @package Rexlabs\Smokescreen\Tests\Unit\Transformer
+ */
+class PipelineTest extends TestCase
+{
+    /**
+     * @test
+     * @return void
+     * @throws IncludeException
+     */
+    public function null_root_resource_returns_null()
+    {
+        $pipeline = new Pipeline();
+        $result = $pipeline->run(new Scope(null, new Includes()));
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Transformer/PipelineTest.php
+++ b/tests/Unit/Transformer/PipelineTest.php
@@ -9,16 +9,16 @@ use Rexlabs\Smokescreen\Transformer\Pipeline;
 use Rexlabs\Smokescreen\Transformer\Scope;
 
 /**
- * Class PipelineTest
- *
- * @package Rexlabs\Smokescreen\Tests\Unit\Transformer
+ * Class PipelineTest.
  */
 class PipelineTest extends TestCase
 {
     /**
      * @test
-     * @return void
+     *
      * @throws IncludeException
+     *
+     * @return void
      */
     public function null_root_resource_returns_null()
     {


### PR DESCRIPTION
Documents that don't nest includes aren't possible with current smokescreen. Adding a "compositor" allows users to customise the arrangement of their serialized items and collections in the document.

 - Create tree data structure (scopes and nodes)
 - Abstract away recursion for flat scope traversals
 - Add composition concept - arranging the entire document
 - Split out logical steps: transformation, serialization, composition
 - Update tests

New pipeline:

 - Transform all data
 - Serialize items, collections and nulls
 - Compose data into a document

Companion PR for [smokescreen-laravel-php](https://github.com/rexlabsio/smokescreen-laravel-php/pull/18)