### PR TITLE
Serializer to return collections without pagination or data key

### DIFF
--- a/src/Serializer/SimpleCollectionSerializer.php
+++ b/src/Serializer/SimpleCollectionSerializer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Serializer;
+
+use Rexlabs\Smokescreen\Pagination\CursorInterface;
+use Rexlabs\Smokescreen\Pagination\PaginatorInterface;
+
+/**
+ * Serializer to return simple collections:
+ * - Returns collections without nesting them under a "data" key
+ * - Returns items without any nesting.
+ * - Does not support pagination
+ * - Does not support cursor
+ */
+class SimpleCollectionSerializer extends DefaultSerializer
+{
+    /**
+     * Serialize a collection.
+     * The data will NOT be nested under a "data" key.
+     *
+     * @param string $resourceKey
+     * @param array  $data
+     *
+     * @return array
+     */
+    public function collection($resourceKey, array $data): array
+    {
+        return $data;
+    }
+
+    /**
+     * Serialize the paginator.
+     *
+     * @param PaginatorInterface $paginator
+     *
+     * @return array
+     */
+    public function paginator(PaginatorInterface $paginator)
+    {
+        return [];
+    }
+
+    /**
+     * Serialize the cursor.
+     *
+     * @param CursorInterface $cursor
+     *
+     * @return array
+     */
+    public function cursor(CursorInterface $cursor): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Serializer/SimpleCollectionSerializerTest.php
+++ b/tests/Unit/Serializer/SimpleCollectionSerializerTest.php
@@ -51,7 +51,7 @@ class SimpleCollectionSerializerTest extends TestCase
     }
 
     /** @test */
-    public function cannot_serialize_paginator()
+    public function serializes_an_empty_paginator()
     {
         $serializer = new SimpleCollectionSerializer;
         $paginator = $this->createPaginator();
@@ -60,7 +60,7 @@ class SimpleCollectionSerializerTest extends TestCase
     }
 
     /** @test */
-    public function cannot_serialize_cursor()
+    public function serializes_an_empty_cursor()
     {
         $serializer = new SimpleCollectionSerializer();
         $cursor = $this->createCursor();

--- a/tests/Unit/Serializer/SimpleCollectionSerializerTest.php
+++ b/tests/Unit/Serializer/SimpleCollectionSerializerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Rexlabs\Smokescreen\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Rexlabs\Smokescreen\Pagination\CursorInterface;
+use Rexlabs\Smokescreen\Pagination\PaginatorInterface;
+use Rexlabs\Smokescreen\Serializer\SimpleCollectionSerializer;
+
+class SimpleCollectionSerializerTest extends TestCase
+{
+    /** @test */
+    public function can_serialize_collection_without_data_property()
+    {
+        $data = [
+            [
+                'id'    => 1,
+                'title' => 'Pride and Prejudice',
+            ],
+            [
+                'id'    => 2,
+                'title' => '1982',
+            ],
+        ];
+
+        $serializer = new SimpleCollectionSerializer();
+
+        $this->assertEquals($data, $serializer->collection(null, $data));
+    }
+
+    /** @test */
+    public function can_serialize_item()
+    {
+        $data = [
+            'id'    => 1,
+            'title' => 'Pride and Prejudice',
+        ];
+
+        $serializer = new SimpleCollectionSerializer();
+
+        $this->assertEquals($data, $serializer->item(null, $data));
+    }
+
+    /** @test */
+    public function can_serialize_null()
+    {
+        $serializer = new SimpleCollectionSerializer();
+
+        $this->assertEquals([], $serializer->nullCollection());
+        $this->assertEquals(null, $serializer->nullItem());
+    }
+
+    /** @test */
+    public function cannot_serialize_paginator()
+    {
+        $serializer = new SimpleCollectionSerializer;
+        $paginator = $this->createPaginator();
+
+        $this->assertEquals([], $serializer->paginator($paginator));
+    }
+
+    /** @test */
+    public function cannot_serialize_cursor()
+    {
+        $serializer = new SimpleCollectionSerializer();
+        $cursor = $this->createCursor();
+
+        $this->assertEquals([], $serializer->cursor($cursor));
+    }
+
+    /**
+     * @return CursorInterface
+     */
+    public function createCursor(): CursorInterface
+    {
+        return new class() implements CursorInterface {
+            public function getCurrent()
+            {
+                return 'current';
+            }
+
+            public function getPrev()
+            {
+                return 'prev';
+            }
+
+            public function getNext()
+            {
+                return 'next';
+            }
+
+            public function getCount(): int
+            {
+                return 10;
+            }
+        };
+    }
+
+    /**
+     * @param int $total
+     * @param int $currentPage
+     *
+     * @return PaginatorInterface
+     */
+    public function createPaginator(int $total = 10, int $currentPage = 1): PaginatorInterface
+    {
+        return new class($total, $currentPage) implements PaginatorInterface {
+            protected $perPage = 15;
+            protected $total;
+            protected $currentPage;
+
+            public function __construct($total, $currentPage)
+            {
+                $this->total = $total;
+                $this->currentPage = $currentPage;
+            }
+
+            public function getCurrentPage(): int
+            {
+                return $this->currentPage;
+            }
+
+            public function getLastPage(): int
+            {
+                return ceil($this->total / $this->perPage);
+            }
+
+            public function getTotal(): int
+            {
+                return $this->total;
+            }
+
+            public function getCount(): int
+            {
+                $offset = ($this->currentPage - 1) * $this->perPage;
+                $remainder = $this->total - $offset;
+
+                return $remainder < $this->perPage ? $remainder : $this->perPage;
+            }
+
+            public function getPerPage(): int
+            {
+                return $this->perPage;
+            }
+
+            public function getUrl($page): string
+            {
+                return "http://localhost/$page";
+            }
+        };
+    }
+}


### PR DESCRIPTION
As discussed, this PR adds a serializer to return collections without `data` key, pagination and cursor. If you don't like the name, you pick one 😉 