### PR TITLE
chore: allow method to be a callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.0
+
+### New Features
+
+* Allow method directive for includes to be a closure instead of a string that refers to a method on the class
+
 ## 2.1.0
 
 ### General Changes

--- a/src/Transformer/Pipeline.php
+++ b/src/Transformer/Pipeline.php
@@ -208,6 +208,9 @@ class Pipeline
         // Transformer explicitly provided an include method
         $transformer = $scope->transformer();
         $method = $includeDefinition['method'];
+        if(is_callable($method)){
+            return $method($data, $scope);
+        }
         if (method_exists($transformer, $method)) {
             return $transformer->$method($data, $scope);
         }


### PR DESCRIPTION
Allows callable methods to be executed, instead of just string methods. This facilitates modifications to the transformers in Rex PM.